### PR TITLE
1.21.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import java.nio.charset.StandardCharsets
 plugins {
     id("com.gradleup.shadow") version "9.0.0-beta4"
     id 'java-library'
-    id 'io.papermc.paperweight.userdev' version "2.0.0-beta.11" apply false
+    id 'io.papermc.paperweight.userdev' version "2.0.0-beta.18" apply false
 }
 
 group = 'com.jacky8399'
@@ -51,10 +51,11 @@ dependencies {
     implementation(project(path: ":v1_21_1_R1", configuration: 'reobf'))
     implementation(project(path: ":v1_21_3_R1", configuration: 'reobf'))
     implementation(project(path: ":v1_21_4_R1", configuration: 'reobf'))
+    implementation(project(path: ":v1_21_5_R1", configuration: 'reobf'))
 
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.6")
     implementation("org.bstats:bstats-bukkit:3.0.0")
-    compileOnlyApi "com.comphenix.protocol:ProtocolLib:5.1.0"
+    compileOnlyApi "net.dmulloy2:ProtocolLib:5.4.0"
 }
 
 // replace plugin.yml version with Gradle build version

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -5,7 +5,7 @@ plugins {
 group 'com.jacky8399.fakesnow'
 
 dependencies {
-    compileOnlyApi "org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT"
-    compileOnlyApi "com.comphenix.protocol:ProtocolLib:5.1.0"
+    compileOnlyApi "io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT"
+    compileOnlyApi "net.dmulloy2:ProtocolLib:5.4.0"
     compileOnlyApi "org.jetbrains:annotations:23.0.0"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,4 +12,4 @@ include 'common'
 include 'v1_21_1_R1'
 include 'v1_21_3_R1'
 include 'v1_21_4_R1'
-
+include 'v1_21_5_R1'

--- a/src/main/java/com/jacky8399/fakesnow/FakeSnow.java
+++ b/src/main/java/com/jacky8399/fakesnow/FakeSnow.java
@@ -6,6 +6,7 @@ import com.comphenix.protocol.utility.MinecraftVersion;
 import com.jacky8399.fakesnow.v1_21_1_R1.PacketListener_v1_21_1_R1;
 import com.jacky8399.fakesnow.v1_21_3_R1.PacketListener_v1_21_3_R1;
 import com.jacky8399.fakesnow.v1_21_4_R1.PacketListener_v1_21_4_R1;
+import com.jacky8399.fakesnow.v1_21_5_R1.PacketListener_v1_21_5_R1;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -46,6 +47,8 @@ public final class FakeSnow extends JavaPlugin {
         String bukkitVersion = Bukkit.getServer().getBukkitVersion();
         if (!MinecraftVersion.getCurrentVersion().isAtLeast(new MinecraftVersion("1.21"))) {
             throw new IllegalStateException("Only Minecraft 1.21 is supported");
+        } else if (bukkitVersion.startsWith("1.21.5")) {
+            packetListener = new PacketListener_v1_21_5_R1(this); // 1.21.5
         } else if (bukkitVersion.startsWith("1.21.4")) {
             packetListener = new PacketListener_v1_21_4_R1(this); // 1.21.4
         } else if (bukkitVersion.startsWith("1.21.2") || bukkitVersion.startsWith("1.21.3")) {

--- a/v1_21_5_R1/build.gradle
+++ b/v1_21_5_R1/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'java-library'
+    id 'io.papermc.paperweight.userdev'
+}
+
+group 'com.jacky8399.fakesnow.v1_21_5_R1'
+
+dependencies {
+    paperweight.paperDevBundle("1.21.5-R0.1-SNAPSHOT")
+    implementation(project(":common"))
+}
+
+// https://github.com/PaperMC/paperweight/issues/143
+tasks.named("assemble") {
+    dependsOn tasks.named("reobfJar")
+}

--- a/v1_21_5_R1/src/main/java/com/jacky8399/fakesnow/v1_21_5_R1/PacketListener_v1_21_5_R1.java
+++ b/v1_21_5_R1/src/main/java/com/jacky8399/fakesnow/v1_21_5_R1/PacketListener_v1_21_5_R1.java
@@ -1,4 +1,4 @@
-package com.jacky8399.fakesnow.v1_21_4_R1;
+package com.jacky8399.fakesnow.v1_21_5_R1;
 
 import com.comphenix.protocol.events.PacketEvent;
 import com.jacky8399.fakesnow.Config;
@@ -31,9 +31,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumMap;
 
-public class PacketListener_v1_21_4_R1 extends PacketListener {
+public class PacketListener_v1_21_5_R1 extends PacketListener {
 
-    public PacketListener_v1_21_4_R1(Plugin plugin) {
+    public PacketListener_v1_21_5_R1(Plugin plugin) {
         super(plugin);
     }
 


### PR DESCRIPTION
The plugin did not work correctly on version 1.21.5 (I did not test it on higher versions). It gave the following error:

```
[FakeSnow] Unhandled exception number 128 occurred in onPacketSending(PacketEvent) for FakeSnow
java.lang.NoClassDefFoundError: org/bukkit/craftbukkit/v1_21_R1/CraftChunk
  at FakeSnow-1.3.3.jar/com.jacky8399.fakesnow.v1_21_1_R1.PacketListener_v1_21_1_R1.updatePacketOld(PacketListener_v1_21_1_R1.java:149) ~[FakeSnow-1.3.3.jar:?]
  at FakeSnow-1.3.3.jar/com.jacky8399.fakesnow.v1_21_1_R1.PacketListener_v1_21_1_R1.onPacketSending(PacketListener_v1_21_1_R1.java:348) ~[FakeSnow-1.3.3.jar:?]
```

When I recompiled the plugin and added support for 1.21.5 (by simply copying the code for 1.21.4), the "old packet handler" started working, but "fast packet handler" for some reason kicks players with the error "Network Protocol Error".

In general, the code from this pull request fixes the compilation and makes it possible to use the plugin on version 1.21.5 using the "old packet handler" without errors.